### PR TITLE
Fixed sorting inline property definitions

### DIFF
--- a/src/reprinter/index.test.ts
+++ b/src/reprinter/index.test.ts
@@ -1,8 +1,8 @@
-import { sentenceCase } from "../common/string-utils";
 import { expect } from 'chai';
 import { readFileSync } from "fs";
 import { sync } from "globby";
 import { basename, join } from "path";
+import { sentenceCase } from "../common/string-utils";
 
 // The methods being tested here
 import { Reprinter } from './index';
@@ -44,7 +44,7 @@ describe('reprinter', () => {
       testInfos.forEach(testInfo => {
         if (testInfo.parserType === parserType) {
           // Useful if you need to test a single file
-          // if (testInfo.testName.includes("Readme example"))
+          // if (testInfo.testName.includes("Inline property"))
           it(testInfo.testName, () => {
             let expected = readFileSync(testInfo.outputFilePath, "utf8");
             let actual = new Reprinter(testInfo.inputFilePath, {}).getRewrittenFileContents();

--- a/src/reprinter/index.ts
+++ b/src/reprinter/index.ts
@@ -17,8 +17,8 @@ import { sortTSPropertySignatures } from "../sortTSPropertySignatures";
 import { sortUnionTypeAnnotation } from "../sortUnionTypeAnnotation";
 
 // Utils
-import { endsWith } from "../common/string-utils";
 import { isArray } from "util";
+import { endsWith } from "../common/string-utils";
 
 export interface ReprinterOptions {
     isHelpMode?: boolean,
@@ -384,8 +384,12 @@ export class Reprinter {
                     case "NumberLiteralTypeAnnotation":
                     case "NumberTypeAnnotation":
                     case "StringLiteralTypeAnnotation":
-                    case "StringTypeAnnotation":
+                    case "StringTypeAnnotation": {
+                        if (node.typeParameters && node.typeParameters.params) {
+                            fileContents = this.rewriteNodes(node.typeParameters.params, comments, fileContents);
+                        }
                         break;
+                    }
 
                     // From typescript or flow - TODO need to split these
                     case "ClassProperty": {

--- a/src/reprinter/index.ts
+++ b/src/reprinter/index.ts
@@ -385,7 +385,7 @@ export class Reprinter {
                     case "NumberTypeAnnotation":
                     case "StringLiteralTypeAnnotation":
                     case "StringTypeAnnotation": {
-                        if (node.typeParameters && node.typeParameters.params) {
+                        if (node.typeParameters != null && node.typeParameters.params != null) {
                             fileContents = this.rewriteNodes(node.typeParameters.params, comments, fileContents);
                         }
                         break;

--- a/src/reprinter/test_assets/flow.nested_readonly.input.js.txt
+++ b/src/reprinter/test_assets/flow.nested_readonly.input.js.txt
@@ -6,6 +6,6 @@ interface Definition {
     | $ReadOnly<{| +alternative: {
       c: boolean,
       b: boolean,
-      a: boolean,
+      a: boolean
     }, +former: string|}>
 }

--- a/src/reprinter/test_assets/flow.nested_readonly.input.js.txt
+++ b/src/reprinter/test_assets/flow.nested_readonly.input.js.txt
@@ -1,0 +1,11 @@
+interface Definition {
+  property: 
+    | $ReadOnly<{| +latter: string, +former: boolean|}>
+    | $ReadOnly<{| 
+        +differ: string, +former: boolean|}>
+    | $ReadOnly<{| +alternative: {
+      c: boolean,
+      b: boolean,
+      a: boolean,
+    }, +former: string|}>
+}

--- a/src/reprinter/test_assets/flow.nested_readonly.output.js.txt
+++ b/src/reprinter/test_assets/flow.nested_readonly.output.js.txt
@@ -1,10 +1,10 @@
 interface Definition {
   property: 
-    | $ReadOnly<{| +alternative: {
+    | $ReadOnly<{| +former: string, +alternative: {
       a: boolean,
       b: boolean,
-      c: boolean,
-    }, +former: string|}>
+      c: boolean
+    }|}>
     | $ReadOnly<{| 
         +differ: string, +former: boolean|}>
     | $ReadOnly<{| +former: boolean, +latter: string|}>

--- a/src/reprinter/test_assets/flow.nested_readonly.output.js.txt
+++ b/src/reprinter/test_assets/flow.nested_readonly.output.js.txt
@@ -1,0 +1,11 @@
+interface Definition {
+  property: 
+    | $ReadOnly<{| +alternative: {
+      a: boolean,
+      b: boolean,
+      c: boolean,
+    }, +former: string|}>
+    | $ReadOnly<{| 
+        +differ: string, +former: boolean|}>
+    | $ReadOnly<{| +former: boolean, +latter: string|}>
+}

--- a/src/reprinter/test_assets/typescript.inline_property.input.ts.txt
+++ b/src/reprinter/test_assets/typescript.inline_property.input.ts.txt
@@ -1,0 +1,26 @@
+export interface IExample {
+  level_1_2: {
+    level_2_2: {
+      level_3_3: number,
+      level_3_1: number,
+      level_3_2: number,
+    },
+    level_2_1: {
+      level_3_3: number,
+      level_3_1: number,
+      level_3_2: number,
+    }
+  },
+  level_1_1: {
+    level_2_2: {
+      level_3_3: number,
+      level_3_1: number,
+      level_3_2: number
+    },
+    level_2_1: {
+      level_3_3: number,
+      level_3_1: number,
+      level_3_2: number
+    }
+  }
+}

--- a/src/reprinter/test_assets/typescript.inline_property.output.ts.txt
+++ b/src/reprinter/test_assets/typescript.inline_property.output.ts.txt
@@ -1,0 +1,26 @@
+export interface IExample {
+  level_1_1: {
+    level_2_1: {
+      level_3_1: number,
+      level_3_2: number,
+      level_3_3: number
+    },
+    level_2_2: {
+      level_3_1: number,
+      level_3_2: number,
+      level_3_3: number
+    }
+  },
+  level_1_2: {
+    level_2_1: {
+      level_3_1: number,
+      level_3_2: number,
+      level_3_3: number,
+    },
+    level_2_2: {
+      level_3_1: number,
+      level_3_2: number,
+      level_3_3: number,
+    }
+  }
+}

--- a/src/sortTSPropertySignatures/index.ts
+++ b/src/sortTSPropertySignatures/index.ts
@@ -9,7 +9,7 @@ export interface SortTSPropertySignaturesOptions {
 export function sortTSPropertySignatures(properties: any, comments: Comment[], fileContents: string, options?: SortTSPropertySignaturesOptions) {
   let ensuredOptions = ensureOptions(options);
   let newFileContents = fileContents.slice();
-  let allNodes: any[] = properties;
+  let allNodes: any[] = cleanProperties(fileContents, properties);
 
   // Any time there is a spread operator, we need to sort around it... moving it could cause functionality changes
   let spreadGroups: any[] = [];
@@ -67,6 +67,24 @@ function ensureOptions(options?: SortTSPropertySignaturesOptions | null): SortTS
   return {
     groups: options.groups || ["undefined", "null", "*", "object", "function"],
   };
+}
+
+function cleanProperties(fileContents: string, properties: any[]) {
+  // Interface properties are read in as "property: number," where we don't want to move the commas
+  return properties.map((property: any) => {
+    let lastIndex = property.range[1];
+    if (0 < lastIndex &&
+      fileContents[lastIndex - 1] === ',') {
+      lastIndex--;
+    }
+
+    return {
+      ...property,
+      range: [
+        property.range[0], lastIndex
+      ]
+    }
+  });
 }
 
 function getString(property, fileContents: string) {

--- a/src/sortUnionTypeAnnotation/index.ts
+++ b/src/sortUnionTypeAnnotation/index.ts
@@ -133,6 +133,9 @@ class UnionTypeAnnotationSorter {
       return a.raw;
     }
     else if (a.type === "GenericTypeAnnotation") {
+      if (a.id.name === "$ReadOnly") {
+        return a.typeParameters.params[0].properties[0].key.name;
+      }
       return a.id.name;
     }
     else if (a.type === "TSLastTypeNode") {

--- a/src/sortUnionTypeAnnotation/test_assets/flow.read_only_union.input.txt
+++ b/src/sortUnionTypeAnnotation/test_assets/flow.read_only_union.input.txt
@@ -1,0 +1,7 @@
+interface Definition {
+  property: 
+    | $ReadOnly<{| +latter: string, +former: boolean|}>
+    | $ReadOnly<{| 
+        +differ: string, +former: boolean|}>
+    | $ReadOnly<{| +alternative: string, +former: boolean|}>
+}

--- a/src/sortUnionTypeAnnotation/test_assets/flow.read_only_union.output.txt
+++ b/src/sortUnionTypeAnnotation/test_assets/flow.read_only_union.output.txt
@@ -1,0 +1,7 @@
+interface Definition {
+  property: 
+    | $ReadOnly<{| +alternative: string, +former: boolean|}>
+    | $ReadOnly<{| 
+        +differ: string, +former: boolean|}>
+    | $ReadOnly<{| +latter: string, +former: boolean|}>
+}


### PR DESCRIPTION
For inline property definitions such as 
```
export interface Example {
   property: {
     subproperty2: 2,
     subproperty1: 1, 
   }
}
```
the two sub-properties would not be sorted