### PR TITLE
Fixed typescript parser extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,12 +64,12 @@
     "ts-node": "7.0.1"
   },
   "dependencies": {
-    "cosmiconfig": "^5.0.5",
+    "cosmiconfig": "^5.0.6",
     "flow-parser": "^0.81.0",
     "fs": "0.0.2",
     "globby": "^8.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "^3.0.0",
-    "typescript-eslint-parser": "^18.0.0"
+    "typescript": "^3.0.3",
+    "typescript-estree": "^1.0.0"
   }
 }

--- a/src/parsers/typescript/index.ts
+++ b/src/parsers/typescript/index.ts
@@ -1,6 +1,6 @@
 // Mostly taken from Prettier.io - Credit where credit is due!
 
-import * as parser from "typescript-eslint-parser";
+import * as parser from "typescript-estree";
 import { createError, includeShebang } from "../../common/parser-utils";
 
 export function parse(text: string /*, parsers, opts*/) {


### PR DESCRIPTION
Looks like typescript-estree was pulled out from typescript-eslint-parser. This change fixes the dependencies.