### PR TITLE
Add sortImportDeclarationSpecifiers to general js overrides

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### 2.6.2
 
-- Added `sortImportDeclarationSpecifiers` to the public options (Thanks @abrougher)
+- Added `sortImportDeclarationSpecifiers` to the public options (Thanks @abrougher for the bug)
 
 ### 2.6.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+### 2.6.2
+
+- Added `sortImportDeclarationSpecifiers` to the public options (Thanks @abrougher)
+
 ### 2.6.1
 
 - Improved `.sortierignore` file support for monorepos by using the closest .sortierignore file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowcoders/sortier",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,5 +63,5 @@
     "start": "npm run build && node bin/index.js",
     "test": "nyc npm run mocha"
   },
-  "version": "2.6.1"
+  "version": "2.6.2"
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,16 +2,42 @@ import { expect } from "chai";
 import { join } from "path";
 import { formatFile, formatText } from "./index";
 
-it("Runs without crashing", () => {
-  let thisFile = join(__dirname, "index.test.ts");
-  formatFile(thisFile, {
-    isTestRun: true
+describe("index", () => {
+  it("Runs without crashing", () => {
+    let thisFile = join(__dirname, "index.test.ts");
+    formatFile(thisFile, {
+      isTestRun: true
+    });
   });
-});
 
-it("Runs formatText without crashing", () => {
-  let result = formatText("ts", "let a = {b: 'b', a: 'a'};", {
-    isTestRun: true
+  it("Runs formatText without crashing", () => {
+    let result = formatText("ts", "let a = {b: 'b', a: 'a'};", {
+      isTestRun: true
+    });
+    expect(result).to.equal("let a = {a: 'a', b: 'b'};");
   });
-  expect(result).to.equal("let a = {a: 'a', b: 'b'};");
+
+  describe("Validating option overrides", () => {
+    it("js.sortImportDeclarationSpecifiers.groups = undefined", () => {
+      let result = formatText("ts", "import { IP, Po } from '@foo';", {
+        js: {
+          sortImportDeclarationSpecifiers: {
+            groups: undefined
+          }
+        }
+      });
+      expect(result).to.equal("import { Po, IP } from '@foo';");
+    });
+
+    it("js.sortImportDeclarationSpecifiers.groups = *", () => {
+      let result = formatText("ts", "import { Po, IP } from '@foo';", {
+        js: {
+          sortImportDeclarationSpecifiers: {
+            groups: ["*"]
+          }
+        }
+      });
+      expect(result).to.equal("import { IP, Po } from '@foo';");
+    });
+  });
 });

--- a/src/language-js/reprinter/index.ts
+++ b/src/language-js/reprinter/index.ts
@@ -33,9 +33,7 @@ import {
 } from "../sortClassContents";
 import { TypeAnnotationOption } from "../utilities/sort-utils";
 
-export type ReprinterOptions = Partial<ReprinterOptionsRequired>;
-
-export interface ReprinterOptionsRequired {
+export interface ReprinterOptions {
   // Default undefined. The parser to use. If undefined, sortier will determine the parser to use based on the file extension
   parser?: "flow" | "typescript";
   // Default undefined. If defined, class contents will be sorted based on the options provided. Turned off by default because it will sort over blank lines.
@@ -43,7 +41,7 @@ export interface ReprinterOptionsRequired {
   // Default ["*", "interfaces", "types"] (see SortImportDeclarationSpecifiersOptions)
   sortImportDeclarationSpecifiers?: SortImportDeclarationSpecifiersOptions;
   // Default "source". The order you wish to sort import statements. Source is the path the import comes from. First specifier is the first item imported.
-  sortImportDeclarations: SortImportDeclarationsOrderOption;
+  sortImportDeclarations?: SortImportDeclarationsOrderOption;
   // Default ["undefined", "null", "*", "function"]. The order to sort object types when encountered.
   sortTypeAnnotations?: TypeAnnotationOption[];
 }
@@ -54,7 +52,7 @@ export class Reprinter implements ILanguage {
 
   private _filename: string;
   private _helpModeHasPrintedFilename: boolean;
-  private _options: ReprinterOptionsRequired;
+  private _options: ReprinterOptions;
 
   public getRewrittenContents(
     filename: string,
@@ -79,11 +77,18 @@ export class Reprinter implements ILanguage {
     ]);
   }
 
-  private getValidatedOptions(
-    appOptions: ReprinterOptions
-  ): ReprinterOptionsRequired {
-    let partialOptions = {
-      ...appOptions,
+  private getValidatedOptions(appOptions: ReprinterOptions): ReprinterOptions {
+    // TODO: v3.0.0 - Remove extends JavascriptReprinterOptions
+    let {
+      css,
+      isHelpMode,
+      isTestRun,
+      js,
+      logLevel,
+      ...onlyJsOptions
+    } = appOptions;
+    let partialOptions: ReprinterOptions = {
+      ...onlyJsOptions,
       ...appOptions.js
     };
     let sortTypeAnnotations:
@@ -99,7 +104,7 @@ export class Reprinter implements ILanguage {
       sortClassContents: partialOptions.sortClassContents,
       sortImportDeclarationSpecifiers:
         partialOptions.sortImportDeclarationSpecifiers,
-      sortImportDeclarations: partialOptions.sortImportDeclarations || "source",
+      sortImportDeclarations: partialOptions.sortImportDeclarations,
       sortTypeAnnotations: sortTypeAnnotations
     };
   }

--- a/src/language-js/reprinter/index.ts
+++ b/src/language-js/reprinter/index.ts
@@ -6,7 +6,10 @@ import { parse as parseTypescript } from "../parsers/typescript";
 
 // Types of sorts
 import { sortExpression } from "../sortExpression";
-import { sortImportDeclarationSpecifiers } from "../sortImportDeclarationSpecifiers";
+import {
+  SortImportDeclarationSpecifiersOptions,
+  sortImportDeclarationSpecifiers
+} from "../sortImportDeclarationSpecifiers";
 import {
   SortImportDeclarationsOrderOption,
   sortImportDeclarations
@@ -35,15 +38,14 @@ export type ReprinterOptions = Partial<ReprinterOptionsRequired>;
 export interface ReprinterOptionsRequired {
   // Default undefined. The parser to use. If undefined, sortier will determine the parser to use based on the file extension
   parser?: "flow" | "typescript";
-
-  // Default "source". The order you wish to sort import statements. Source is the path the import comes from. First specifier is the first item imported.
-  sortImportDeclarations: SortImportDeclarationsOrderOption;
-
-  // Default ["undefined", "null", "*", "function"]. The order to sort object types when encountered.
-  sortTypeAnnotations?: TypeAnnotationOption[];
-
   // Default undefined. If defined, class contents will be sorted based on the options provided. Turned off by default because it will sort over blank lines.
   sortClassContents?: SortClassContentsOptions;
+  // Default ["*", "interfaces", "types"] (see SortImportDeclarationSpecifiersOptions)
+  sortImportDeclarationSpecifiers?: SortImportDeclarationSpecifiersOptions;
+  // Default "source". The order you wish to sort import statements. Source is the path the import comes from. First specifier is the first item imported.
+  sortImportDeclarations: SortImportDeclarationsOrderOption;
+  // Default ["undefined", "null", "*", "function"]. The order to sort object types when encountered.
+  sortTypeAnnotations?: TypeAnnotationOption[];
 }
 
 export class Reprinter implements ILanguage {
@@ -95,6 +97,8 @@ export class Reprinter implements ILanguage {
     return {
       parser: partialOptions.parser,
       sortClassContents: partialOptions.sortClassContents,
+      sortImportDeclarationSpecifiers:
+        partialOptions.sortImportDeclarationSpecifiers,
       sortImportDeclarations: partialOptions.sortImportDeclarations || "source",
       sortTypeAnnotations: sortTypeAnnotations
     };
@@ -278,7 +282,8 @@ export class Reprinter implements ILanguage {
               fileContents = sortImportDeclarationSpecifiers(
                 node.specifiers,
                 comments,
-                fileContents
+                fileContents,
+                this._options.sortImportDeclarationSpecifiers
               );
             }
             break;
@@ -346,7 +351,8 @@ export class Reprinter implements ILanguage {
             fileContents = sortImportDeclarationSpecifiers(
               node.specifiers,
               comments,
-              fileContents
+              fileContents,
+              this._options.sortImportDeclarationSpecifiers
             );
             break;
           }

--- a/src/language-js/sortImportDeclarationSpecifiers/index.ts
+++ b/src/language-js/sortImportDeclarationSpecifiers/index.ts
@@ -3,7 +3,11 @@ import { BaseNode, compare, reorderValues } from "../../utilities/sort-utils";
 
 export type SortByExportOptionsGroups = "*" | "interfaces" | "types";
 
-export interface SortImportDeclarationSpecifiersOptions {
+export type SortImportDeclarationSpecifiersOptions = Partial<
+  SortImportDeclarationSpecifiersOptionsRequired
+>;
+
+interface SortImportDeclarationSpecifiersOptionsRequired {
   groups: SortByExportOptionsGroups[];
 }
 
@@ -20,13 +24,13 @@ export function sortImportDeclarationSpecifiers(
   fileContents: string,
   options?: SortImportDeclarationSpecifiersOptions
 ) {
-  options = ensureOptions(options);
+  let cleanedOptions = ensureOptions(options);
 
   fileContents = sortSingleSpecifier(
     specifiers,
     comments,
     fileContents,
-    options
+    cleanedOptions
   );
 
   return fileContents;
@@ -36,7 +40,7 @@ function sortSingleSpecifier(
   specifiers: any,
   comments: Comment[],
   fileContents: string,
-  options: SortImportDeclarationSpecifiersOptions
+  options: SortImportDeclarationSpecifiersOptionsRequired
 ): string {
   // If there is one or less specifiers, there is not anything to sort
   if (specifiers.length <= 1) {
@@ -125,7 +129,7 @@ function nameIsLikelyInterface(name: string) {
 
 function ensureOptions(
   options?: null | SortImportDeclarationSpecifiersOptions
-): SortImportDeclarationSpecifiersOptions {
+): SortImportDeclarationSpecifiersOptionsRequired {
   if (options == null) {
     return {
       groups: ["*", "interfaces", "types"]

--- a/src/language-js/sortImportDeclarations/index.test.ts
+++ b/src/language-js/sortImportDeclarations/index.test.ts
@@ -98,7 +98,7 @@ describe("language-js/sortImportDeclarations", () => {
   });
 
   describe("es6 - Custom options", () => {
-    it("Sort by first specifier", () => {
+    it("Order by first specifier", () => {
       let input = `import "./styles.scss";
 import "./header.scss";
 import * as React from "react";
@@ -111,6 +111,42 @@ import * as React from "react";
 import honda from "./cars";`;
       let actual = sortImportDeclarations(flowParse(input).body, input, {
         orderBy: "first-specifier"
+      });
+
+      expect(actual).to.equal(output);
+    });
+
+    it("Order by source", () => {
+      let input = `import "./styles.scss";
+import "./header.scss";
+import * as React from "react";
+import honda from "./cars";
+import { Apple } from "./food";`;
+      let output = `import * as React from "react";
+import honda from "./cars";
+import { Apple } from "./food";
+import "./header.scss";
+import "./styles.scss";`;
+      let actual = sortImportDeclarations(flowParse(input).body, input, {
+        orderBy: "source"
+      });
+
+      expect(actual).to.equal(output);
+    });
+
+    it("Order by undefined", () => {
+      let input = `import "./styles.scss";
+import "./header.scss";
+import * as React from "react";
+import honda from "./cars";
+import { Apple } from "./food";`;
+      let output = `import * as React from "react";
+import honda from "./cars";
+import { Apple } from "./food";
+import "./header.scss";
+import "./styles.scss";`;
+      let actual = sortImportDeclarations(flowParse(input).body, input, {
+        orderBy: "source"
       });
 
       expect(actual).to.equal(output);

--- a/src/language-js/sortImportDeclarations/index.ts
+++ b/src/language-js/sortImportDeclarations/index.ts
@@ -3,7 +3,10 @@ import { compare } from "../../utilities/sort-utils";
 import { StringUtils } from "../../utilities/string-utils";
 
 export type SortImportDeclarationsOrderOption = "first-specifier" | "source";
-export interface SortImportDeclarationsOptions {
+export type SortImportDeclarationsOptions = Partial<
+  SortImportDeclarationsOptionsRequired
+>;
+interface SortImportDeclarationsOptionsRequired {
   orderBy: SortImportDeclarationsOrderOption;
 }
 
@@ -178,8 +181,9 @@ export function sortImportDeclarations(
 
 function ensureOptions(
   options: undefined | null | SortImportDeclarationsOptions
-): SortImportDeclarationsOptions {
+): SortImportDeclarationsOptionsRequired {
   return {
-    orderBy: (options && options.orderBy) || "source"
+    orderBy: "source",
+    ...options
   };
 }


### PR DESCRIPTION
This allows for overriding the js import specifiers by specifying it in the sortier configuration:
```
{
  js: {
    sortImportDeclarationSpecifiers: {
      groups: ["*"]
    }
  }
}
```