### PR TITLE
Allow more flexibility with typescript versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ignore": "5.1.8",
     "postcss-less": "4.0.1",
     "postcss-scss": "3.0.5",
-    "typescript": "4.2.4"
+    "typescript": "^4.2.4"
   },
   "description": "An opionated code sorter",
   "devDependencies": {


### PR DESCRIPTION
Typescript is a really big dependency (60MB in `node_modules`) and having multiple versions floating around can really increase the bloat. Using the [caret range](https://docs.npmjs.com/cli/v6/using-npm/semver#caret-ranges-123-025-004) here should allow sortier to use other installed versions of typescript without relying on `resolutions`.