### PR TITLE
Remove autopublish of latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: [beta, latest]
+    branches: [beta]
 
 jobs:
   Publish:


### PR DESCRIPTION
Since we haven't done a latest publish yet... we should probably remove the autopublish as it might cause weird fun to happen