### PR TITLE
Added common-js dist output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .nyc_output
 coverage
 dist
+dist-cjs
 node_modules
 *.log
 

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 # From the .gitignore
 coverage
 dist
+dist-cjs
 node_modules
 
 # Currently many config files are in commonjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Locally generated files
 coverage
 dist
+dist-cjs
 node_modules
 *.log

--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,8 @@
 **
 
 !/dist/**
+!/dist-cjs/**
 !/bin/**
 !/changelog.md
+!/license
 !/readme.md
-!/license

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 # From the .gitignore file
 coverage
 dist
+dist-cjs
 node_modules
 *.log
 

--- a/.sortierignore
+++ b/.sortierignore
@@ -1,6 +1,7 @@
 # From the .gitignore file
 coverage
 dist
+dist-cjs
 node_modules
 *.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added CommonJS output for those who aren't migrated to CJS
 - Breaking
   - Dropped support for node 12 and 14
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,5 @@ import { jest } from "@snowcoders/renovate-config";
 
 export default {
   ...jest,
-  testPathIgnorePatterns: ["<rootDir>/dist/", "<rootDir>/node_modules/"],
+  testPathIgnorePatterns: ["<rootDir>/dist/", "<rootDir>/dist-cjs/", "<rootDir>/node_modules/"],
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "node": ">=16.0.0"
   },
   "exports": {
-    ".": "./dist/lib/index.js"
+    ".": {
+      "import": "./dist/lib/index.js",
+      "require": "./dist-cjs/lib/index.js"
+    }
   },
   "homepage": "https://snowcoders.github.io/sortier",
   "keywords": [
@@ -59,13 +62,16 @@
   ],
   "license": "MIT",
   "name": "sortier",
+  "main": "./dist-cjs/lib/index.js",
   "repository": "github:snowcoders/sortier",
   "scripts": {
-    "build": "tsc -p ./tsconfig.production.json",
+    "build": "concurrently \"npm:build:esm\" \"npm:build:cjs\"",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "build:cjs": "tsc -p ./tsconfig.cjs.json",
     "build:all": "npm run build && npm run build:docs-playground",
     "build:dev": "tsc -p ./tsconfig.json",
     "build:docs-playground": "cd docs && cd playground-src && npm run build:prod",
-    "clean": "rimraf coverage dist",
+    "clean": "rimraf coverage dist dist-cjs",
     "cover": "cat ./coverage/lcov.info | coveralls",
     "husky:commit-msg": "echo 'No commitlint installed'",
     "husky:pre-commit": "npx --no lint-staged",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist-cjs",
+    "rootDir": "./src"
+  },
+  "extends": "./node_modules/@snowcoders/renovate-config/tsconfig.library.cjs.json",
+  "include": ["./src/**/*"],
+  "exclude": ["./src/**/*.test.ts"]
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,5 +3,5 @@
     "sourceMap": false
   },
   "extends": "./tsconfig.json",
-  "exclude": ["./src/**/*test"]
+  "exclude": ["./src/**/*.test.ts"]
 }


### PR DESCRIPTION
# Description

The lack of commonjs output from this package is causing the vscode plugin to have some gnarly build logic to deal with ESM only outputs
https://github.com/snowcoders/sortier-vscode/blob/main/package.json#L69

The plugin has done a decent job of working around the issue however it would just be soo much cleaner if it was able to import cjs

# Required checklist

- [ ] Rebuilt playground
- [ ] Updated docs
- [ ] Updated changelog
- [ ] Wrote unit tests
