### PR TITLE
Fix publish: Add set authtoken

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,9 @@ jobs:
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
+      - name: NPM config
+        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
+
       - name: Install
         run: npm ci --ignore-scripts
 


### PR DESCRIPTION
# Description

Last [publish attempt](https://github.com/snowcoders/sortier/actions/runs/3779282038/jobs/6424418970#step:8:10) resulted in the following error:
```
ERROR Not authenticated with npm. Please `npm login` and try again.
```

Trying to set the auth token before we get to publish

# Required checklist

- [ ] Rebuilt playground (e.g. `npm run prepare -w=src-playground`)
- [ ] Updated docs
- [ ] Updated changelog
- [ ] Wrote unit tests
