### PR TITLE
Publish auth to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,11 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: NPM config
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
+        run: |
+          npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          npm whoami
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install
         run: npm ci --ignore-scripts


### PR DESCRIPTION
# Description

Attempting to fix the npm auth issue during release-it runs
https://github.com/snowcoders/sortier/actions/runs/3779485179/jobs/6424771268#step:9:7

# Required checklist

- [ ] Rebuilt playground (e.g. `npm run prepare -w=src-playground`)
- [ ] Updated docs
- [ ] Updated changelog
- [ ] Wrote unit tests
