### PR TITLE
Fix publish: revert docs after build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,6 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Remove src-playground
-        run: rm -rf ./src-playground
-
       - name: Install
         run: npm ci --ignore-scripts
 
@@ -43,6 +40,9 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Revert docs
+        run: git checkout ./docs
 
       - name: Publish
         run: npx --no release-it -- --ci


### PR DESCRIPTION
# Description

Optional description of the PR here (useful to give more details)

# Required checklist

- [ ] Rebuilt playground (e.g. `npm run prepare -w=src-playground`)
- [ ] Updated docs
- [ ] Updated changelog
- [ ] Wrote unit tests
