### PR TITLE
Fixed typescript@5.0.0 compile time breaks

### DIFF
--- a/src/utilities/sort-utils.ts
+++ b/src/utilities/sort-utils.ts
@@ -415,7 +415,7 @@ function getPrecedingCommentsForSpecifier<NodeType extends BaseNode, CommentType
     const isCommentOwnedByPreviousLine =
       !isTextBetweenStartOfLineAndCommentWhitespace && textBetweenCommentAndSpecifier.indexOf("\n") !== -1;
     const isTextBetweenCommentAndSpecifierWhitespace = textBetweenCommentAndSpecifier.match(/[^\s]/gim) == null;
-    const newLineCount = textBetweenCommentAndSpecifier.match(/\n/gim) || 0;
+    const newLineCount = textBetweenCommentAndSpecifier.match(/\n/gim)?.length || 0;
     if (newLineCount <= 1 && isTextBetweenCommentAndSpecifierWhitespace && !isCommentOwnedByPreviousLine) {
       latestCommentIndex = index;
     }


### PR DESCRIPTION
# Description

[Optional description of the PR here (useful to give more details)](https://github.com/snowcoders/sortier/pull/1995) is blocked due to a (valid) compile time break

# Required checklist

- [ ] Rebuilt playground (e.g. `npm run prepare -w=src-playground`)
- [ ] Updated docs
- [ ] Updated changelog
- [ ] Wrote unit tests
