### PR TITLE
Fix avoid sorting polyfill imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed generics not being sorted
 - Refactored code for sorting switch cases
+- Avoid sorting polyfill imports as it could result in incorrect import order
 
 ## [2.0.0] - 2023-02-10
 

--- a/src/language-js/sortImportDeclarations/index.test.ts
+++ b/src/language-js/sortImportDeclarations/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 
 import { runTestAssetsTests } from "../../utilities/test-utils.js";
 
@@ -26,8 +26,8 @@ import * as React from "react";
 import honda from "./cars.js";
 import { Banana } from "./food.js";
 import { Apple } from "./food.js";`;
-      const output = `import "./header.scss";
-import "./styles.scss";
+      const output = `import "./styles.scss";
+import "./header.scss";
 import { Apple } from "./food.js";
 import { Banana } from "./food.js";
 import * as React from "react";
@@ -48,12 +48,12 @@ import * as React from "react";
 import honda from "./cars.js";
 import { Banana } from "./food.js";
 import { Apple } from "./food.js";`;
-      const output = `import * as React from "react";
+      const output = `import "./styles.scss";
+import "./header.scss";
+import * as React from "react";
 import honda from "./cars.js";
 import { Apple } from "./food.js";
-import { Banana } from "./food.js";
-import "./header.scss";
-import "./styles.scss";`;
+import { Banana } from "./food.js";`;
 
       const parsed = flowParse(input);
       const actual = sortImportDeclarations(parsed, parsed.comments, input, {
@@ -69,11 +69,11 @@ import "./header.scss";
 import * as React from "react";
 import honda from "./cars.js";
 import { Apple } from "./food.js";`;
-      const output = `import * as React from "react";
-import honda from "./cars.js";
-import { Apple } from "./food.js";
+      const output = `import "./styles.scss";
 import "./header.scss";
-import "./styles.scss";`;
+import * as React from "react";
+import honda from "./cars.js";
+import { Apple } from "./food.js";`;
 
       const parsed = flowParse(input);
       const actual = sortImportDeclarations(parsed, parsed.comments, input, {

--- a/src/language-js/sortImportDeclarations/test_assets/es6.polyfill.input.js.txt
+++ b/src/language-js/sortImportDeclarations/test_assets/es6.polyfill.input.js.txt
@@ -1,0 +1,3 @@
+// https://github.com/snowcoders/sortier/issues/2218
+
+import "b"; import "a"; import "c";

--- a/src/language-js/sortImportDeclarations/test_assets/es6.polyfill.output.js.txt
+++ b/src/language-js/sortImportDeclarations/test_assets/es6.polyfill.output.js.txt
@@ -1,0 +1,3 @@
+// https://github.com/snowcoders/sortier/issues/2218
+
+import "b"; import "a"; import "c";

--- a/src/language-js/sortImportDeclarations/test_assets/flow.full_file_test.output.js.txt
+++ b/src/language-js/sortImportDeclarations/test_assets/flow.full_file_test.output.js.txt
@@ -3,12 +3,12 @@
 import * as React from "react"; // Needed to make react work
 import * as ReactDOM from "react-dom";
 
-import "a";
 import {b} from "b";
 import * as c from "c";
-import "./a";
+import "a";
 import {local_b} from "./b";
 import * as local_c from "./c";
+import "./a";
 
 export type Props = {
     foo: number,


### PR DESCRIPTION
# Description

Sometimes polyfills build on each other

```js
import "@formatjs/intl-date-time"
import "@formatjs/en/intl-date-time"
import "@company/intl-date-time"
```

Order is important, we can't reorder these.

# Required checklist

- [ ] Updated docs
- [ ] Updated changelog
- [ ] Wrote unit tests
