### PR TITLE
Fixes #2811 - cosmicconfig needs a searchStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Adds searchStrategy=global option to cosmiconfigSync to restore old config resolution behavior.
+
 ## [2.1.0] - 2025-01-26
 
 - Updated our typescript parsing dependencies

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,7 +26,7 @@ export interface SortierOptions {
  * @returns The loaded options or a default options object
  */
 export function resolveOptions(filepath: string): SortierOptions {
-  const explorer = cosmiconfigSync("sortier");
+  const explorer = cosmiconfigSync("sortier", { searchStrategy: "global" });
   const result = explorer.search(filepath);
   const config = result?.config || {};
   const options = config as SortierOptions;


### PR DESCRIPTION
# Description

cosmicconfig v9 had a breaking changes on config file resolution, this reverts it to the previous resolution strategy.

# Required checklist

- [ ] Updated docs
- [ ] Updated changelog
- [ ] Wrote unit tests
